### PR TITLE
Remove deprecated MatiLoginButton

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,9 @@
-import { NativeModules } from "react-native";
-import MatiLoginButton from "./MatiLoginButton";
+import { NativeModules } from 'react-native';
 
 const { MatiGlobalIdSdk } = NativeModules;
 
 module.exports = {
-  get MatiGlobalIdSdk() {
-    return MatiGlobalIdSdk;
-  },
-  get MatiLoginButton() {
-    return MatiLoginButton;
-    //return require("./MatiLoginButton");
-  }
+	get MatiGlobalIdSdk() {
+		return MatiGlobalIdSdk;
+	}
 };


### PR DESCRIPTION
This PR removes the requirement for the no longer existent MatiLoginButton.js file from the package's index.js file.